### PR TITLE
FIX: docker-compose.yml 파일 생성

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,16 @@
-FROM gradle:8.7-jdk21-alpine as build
+FROM gradle:8.7-jdk21-alpine AS build
 
 WORKDIR /app
-COPY . .
-RUN gradle clean build -x test 
 
+# 1) Gradle 빌드 파일만 먼저 복사
+COPY build.gradle settings.gradle gradle.properties /app/
+COPY gradle /app/gradle
 
-FROM openjdk:23-slim
-WORKDIR /app
-COPY --from=build /app/build/libs/*jar server.jar
-CMD ["java", "-jar","./server.jar"]
+# 2) 의존성 다운로드 / 캐시 가능
+RUN gradle clean build -x test --no-daemon --parallel || true
+
+# 3) 소스 전체 복사
+COPY src /app/src
+
+# 4) 실제 빌드
+RUN gradle clean build -x test --no-daemon --parallel

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  wotd:
+    image: wotd:0.2.0
+    container_name: wotd
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/backend/src/main/java/com/example/apptive_3team/Apptive3teamApplication.java
+++ b/backend/src/main/java/com/example/apptive_3team/Apptive3teamApplication.java
@@ -1,6 +1,5 @@
 package com.example.apptive_3team;
 
-import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,13 +7,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Apptive3teamApplication {
 
 	public static void main(String[] args) {
-		// .env 파일 로드
-		Dotenv dotenv = Dotenv.load();
-
-		// 로드된 값을 환경 변수로 설정
-		System.setProperty("WEATHER_API_KEY", dotenv.get("WEATHER_API_KEY"));
-		System.setProperty("WEATHER_API_URL", dotenv.get("WEATHER_API_URL"));
-
 		SpringApplication.run(Apptive3teamApplication.class, args);
 	}
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,9 +4,7 @@ server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true
 server.servlet.encoding.force=true
 
-spring.datasource.url=jdbc:mysql://wotd-mysql.cvoeg24cii37.ap-northeast-2.rds.amazonaws.com:3306/wotd_mysql
-spring.datasource.username=root
-spring.datasource.password=00000000
+server.address=0.0.0.0
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
@@ -18,16 +16,20 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
-spring.security.oauth2.client.registration.kakao.client-id=0e600f60970f26931088dab4a0064e2a
-spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/kakao
-spring.security.oauth2.client.registration.kakao.scope=profile_nickname
-spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
-spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
-spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
-spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
-spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
+spring.security.oauth2.client.registration.kakao.redirect-uri=${KAKAO_REDIRECT_URI}
+spring.security.oauth2.client.registration.kakao.scope=${KAKAO_SCOPE}
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=${KAKAO_AUTH_GRANT_TYPE}
+spring.security.oauth2.client.registration.kakao.client-name=${KAKAO_CLIENT_NAME}
 
-weather.api.key = ${WEATHER_API_KEY}
-weather.api.url = ${WEATHER_API_URL}
+spring.security.oauth2.client.provider.kakao.authorization-uri=${KAKAO_AUTHORIZATION_URI}
+spring.security.oauth2.client.provider.kakao.token-uri=${KAKAO_TOKEN_URI}
+spring.security.oauth2.client.provider.kakao.user-info-uri=${KAKAO_USER_INFO_URI}
+spring.security.oauth2.client.provider.kakao.user-name-attribute=${KAKAO_USER_NAME_ATTRIBUTE}
+
+weather.api.key=${WEATHER_API_KEY}
+weather.api.url=${WEATHER_API_URL}


### PR DESCRIPTION
# 변경점 👍
- docker-compose.yml 생성하여 도커 빌드시 자동으로 .env를 주입하도록 설정했습니다.
- .env 파일을 생성하여 민감한 key 들을 숨김처리 했습니다.
- `docker-compose.yml`을 사용하면 이미지 빌드 및 컨테이너 종료 명령어가 단순해집니다!

> 컨테이너 종료 및 삭제  명령어 : `docker compose down`
> 컨테이너 빌드 및 실행 명령어 : `docker compose up (-d) --build`
> 백그라운드 실행하지 않으면 로그 종료 : `ctrl + C`

# 버그 해결 💊
 weather-api 브랜치 머지 후에 api key를 찾지 못해 null을 반환하여 비정상 종료 문제와
데이터베이스 연결 정보를 .env 에 넣어두고 불러오지 못해 비정상 종료하는 문제를 해결했습니다.

# 스크린샷 🖼
로컬에서 서버 빌드를 성공했습니다.
<img width="569" alt="로컬에서 서버 빌드에 성공한 이미지" src="https://github.com/user-attachments/assets/bbe714cb-3991-41cc-baff-a0423954a23a" />

# 비고 ✏
배포 주소로 연결은 아직 안된 상태입니다.
해당 PR을 머지한 뒤에 배포 사이트로 연결할 수 있을 것 같습니다!

기존에 `git pull origin develop` 이후 빌드 실패 및 컨테이너 비정상 종료는 해결하였습니다!

- 이미지(버전)을 수정하여 빌드하고 싶은 경우에는 `docker-compose.yml` 파일도 수정해야 합니다!
 
