### PR TITLE
Docs: key 및 url을 env로 치환하던 방식에서, application.yml을 gitignore에 추가하는 방식으로 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -14,3 +14,5 @@ build/
 
 # .pen
 wotd.pem
+
+/src/main/resources/application.yml


### PR DESCRIPTION
url 및 key가 env파일에서 치환되지 않는 문제가 계속 발생하여 gitignore에 application.yml을 추가하고, discord를 통해 개발팀 내부에서만 공유하도록 하여 개인정보를 노출시키지 않게 수정하였습니다.
