### PR TITLE
S3 업로드 가능한 이미지 파일 사이즈 제한 설정 추가

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,19 +17,24 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
-# 데이터베이스 설정
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
-# 이미지 데이터베이스 설정
+# ??? ?? ??????
 cloud.aws.s3.bucket=wotd-s3
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
 cloud.aws.credentials.access-key=${S3_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
 
-# 카카오 로그인 설정
+# Tomcat ?? ???? - ????? ?? ? ???? ?? ??
+server.tomcat.connection-timeout=60s
+
+# ?? ??? ??? ??
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=30MB
+
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 spring.security.oauth2.client.registration.kakao.scope=${KAKAO_SCOPE}
@@ -41,7 +46,6 @@ spring.security.oauth2.client.provider.kakao.token-uri=${KAKAO_TOKEN_URI}
 spring.security.oauth2.client.provider.kakao.user-info-uri=${KAKAO_USER_INFO_URI}
 spring.security.oauth2.client.provider.kakao.user-name-attribute=${KAKAO_USER_NAME_ATTRIBUTE}
 
-# 날씨 조회 설정
 weather.api.key=${WEATHER_API_KEY}
 weather.api.past-url=${WEATHER_API_PAST_URL}
 weather.api.forecast-url=${WEATHER_API_FORECAST_URL}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -21,17 +21,13 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
-# ??? ?? ??????
 cloud.aws.s3.bucket=wotd-s3
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
 cloud.aws.credentials.access-key=${S3_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
 
-# Tomcat ?? ???? - ????? ?? ? ???? ?? ??
 server.tomcat.connection-timeout=60s
-
-# ?? ??? ??? ??
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=30MB
 


### PR DESCRIPTION
# 변경점 👍
 - 주석 한글 깨짐 오류 처리(LF -> CRLF) > 한글 주석 모두 제거 했습니다.
- 서버 타임아웃 시간 연장
- 파일 사이즈 제한 추가

> 파일 1개 당 최대 10MB 까지 허용
> 파일 n개 1회 요청시 최대 30MB 까지 허용