### PR TITLE
Feat: 추천 코디 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/apptive_3team/controller/StylingController.java
+++ b/backend/src/main/java/com/example/apptive_3team/controller/StylingController.java
@@ -1,0 +1,43 @@
+package com.example.apptive_3team.controller;
+
+import com.example.apptive_3team.ApiResponse;
+import com.example.apptive_3team.dto.StylingSuggestionRequestDTO;
+import com.example.apptive_3team.dto.StylingSuggestionResponseDTO;
+import com.example.apptive_3team.entity.MoodReport;
+import com.example.apptive_3team.service.KakaoService;
+import com.example.apptive_3team.service.MoodReportService;
+import com.example.apptive_3team.service.StylingService;
+import com.example.apptive_3team.service.WeatherApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/stylingSuggestion")
+@RequiredArgsConstructor
+public class StylingController {
+
+    private final StylingService stylingService;
+    private final MoodReportService moodReportService;
+    private final WeatherApiService weatherApiService;
+    private final KakaoService kakaoService;
+
+    @PostMapping("/request")
+    public ResponseEntity<?> getStylingSuggestionFromMoodReports(@RequestHeader("Authorization") String token,
+                                                                 @RequestBody StylingSuggestionRequestDTO request) {
+
+        Long user_id = kakaoService.getUserIdFromJwtToken(token);
+        List<MoodReport> moodReports = moodReportService.getMoodReportsByUserId(user_id);
+        List<Long> weatherIds = moodReports.stream()
+                .map(MoodReport::getWeatherId)
+                .collect(Collectors.toList());
+        List<Long> filteredWeatherIds = weatherApiService.getSimilarWeatherIdsFromIds(weatherIds, request.temp_feels_like(), request.rain_amount());
+        List<MoodReport> filteredMoodReports = moodReportService.getMoodReportsByWeatherIdsAndUserId(filteredWeatherIds, user_id);
+        StylingSuggestionResponseDTO data = stylingService.StylingSuggestion(filteredMoodReports);
+
+        return ResponseEntity.ok(ApiResponse.success("코디 추천을 완료했습니다.", data));
+    }
+}

--- a/backend/src/main/java/com/example/apptive_3team/controller/StylingController.java
+++ b/backend/src/main/java/com/example/apptive_3team/controller/StylingController.java
@@ -8,6 +8,7 @@ import com.example.apptive_3team.service.KakaoService;
 import com.example.apptive_3team.service.MoodReportService;
 import com.example.apptive_3team.service.StylingService;
 import com.example.apptive_3team.service.WeatherApiService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class StylingController {
 
     @PostMapping("/request")
     public ResponseEntity<?> getStylingSuggestionFromMoodReports(@RequestHeader("Authorization") String token,
-                                                                 @RequestBody StylingSuggestionRequestDTO request) {
+                                                                 @Valid @RequestBody StylingSuggestionRequestDTO request) {
 
         Long user_id = kakaoService.getUserIdFromJwtToken(token);
         List<MoodReport> moodReports = moodReportService.getMoodReportsByUserId(user_id);

--- a/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionDTO.java
+++ b/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionDTO.java
@@ -1,0 +1,12 @@
+package com.example.apptive_3team.dto;
+
+import java.time.LocalDate;
+
+public record StylingSuggestionDTO(Long moodReportId,
+                                   Long weatherId,
+                                   LocalDate date,
+                                   String img_top,
+                                   String img_bottom,
+                                   String img_etc,
+                                   Double score_feel) {
+}

--- a/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionRequestDTO.java
+++ b/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionRequestDTO.java
@@ -1,0 +1,5 @@
+package com.example.apptive_3team.dto;
+
+public record StylingSuggestionRequestDTO(Double temp_feels_like,
+                                          Double rain_amount) {
+}

--- a/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionRequestDTO.java
+++ b/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionRequestDTO.java
@@ -1,5 +1,7 @@
 package com.example.apptive_3team.dto;
 
-public record StylingSuggestionRequestDTO(Double temp_feels_like,
-                                          Double rain_amount) {
+import jakarta.validation.constraints.NotBlank;
+
+public record StylingSuggestionRequestDTO(@NotBlank Double temp_feels_like,
+                                          @NotBlank Double rain_amount) {
 }

--- a/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionResponseDTO.java
+++ b/backend/src/main/java/com/example/apptive_3team/dto/StylingSuggestionResponseDTO.java
@@ -1,0 +1,8 @@
+package com.example.apptive_3team.dto;
+
+import java.util.List;
+
+public record StylingSuggestionResponseDTO(String message,
+                                           int cnt_suggestions,
+                                           List<StylingSuggestionDTO> suggestions) {
+}

--- a/backend/src/main/java/com/example/apptive_3team/service/StylingService.java
+++ b/backend/src/main/java/com/example/apptive_3team/service/StylingService.java
@@ -1,0 +1,89 @@
+package com.example.apptive_3team.service;
+
+import com.example.apptive_3team.dto.StylingSuggestionDTO;
+import com.example.apptive_3team.dto.StylingSuggestionResponseDTO;
+import com.example.apptive_3team.entity.MoodReport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StylingService {
+
+    public StylingSuggestionResponseDTO StylingSuggestion(List<MoodReport> moodReports) {
+
+        // 추천할 코디가 하나도 없는 경우
+        if (moodReports == null || moodReports.isEmpty()) {
+            return new StylingSuggestionResponseDTO(MESSAGE_NO_CODI, 0, Collections.emptyList());
+        }
+
+        Double tempFeelsLike = moodReports.isEmpty() ? null : moodReports.get(0).getScore_feel();
+        String baseMessage = getStyleRecommendation(tempFeelsLike);
+
+        // 유효한 이미지가 있는 무드리포트만 필터링
+        List<StylingSuggestionDTO> validSuggestions = moodReports.stream()
+                .filter(report -> report.getImg_top() != null || report.getImg_bottom() != null || report.getImg_etc() != null)
+                .map(report -> new StylingSuggestionDTO(
+                        report.getId(),
+                        report.getWeatherId(),
+                        report.getDate(),
+                        report.getImg_top(),
+                        report.getImg_bottom(),
+                        report.getImg_etc(),
+                        report.getScore_feel()
+                ))
+                .sorted(Comparator
+                        .comparing(StylingSuggestionDTO::score_feel, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(StylingSuggestionDTO::date, Comparator.reverseOrder())
+                )
+                .collect(Collectors.toList());
+
+        int count = validSuggestions.size();
+        List<StylingSuggestionDTO> topSuggestions = validSuggestions.stream().limit(5).toList();
+
+        String message;
+        if  (count < 5) {
+            message = baseMessage + MESSAGE_INSUFFICIENT_DATA;
+        } else {
+            message = baseMessage;
+        }
+
+        return new StylingSuggestionResponseDTO(message, count, topSuggestions);
+    }
+
+
+    private static final String MESSAGE_NO_CODI = "코디를 채워서 추천을 받아봐요!";
+    private static final String MESSAGE_INSUFFICIENT_DATA = "더 추천받고 싶으시다면 코디를 더 등록해보세요!";
+
+    private static final String VERY_HOT = "날씨가 매우 더운 날이에요! 민소매를 중심으로 시원한 코디 어때요?";
+    private static final String HOT = "날씨가 더운 날이에요! 반팔과 같은 짧은 의류를 추천해요!";
+    private static final String WARM = "너무 짧은 의상은 오늘 날씨에 추울 수 있어요! 얇은 가디건이나 셔츠는 어떨까요?";
+    private static final String COOL = "쌀쌀한 날씨가 예상돼요! 얇은 니트나 가디건을 추천해요!";
+    private static final String MILD = "아직은 봄,가을 날씨! 긴티에 외투가 필요해 보여요!";
+    private static final String CHILLY = "감기 걸리기 쉬운 날이에요! 트렌치코트나 자켓은 어떨까요?";
+    private static final String COLD = "초겨울 날씨에요! 코트나 히트텍 착용을 권장합니다!";
+    private static final String FREEZING = "날씨가 너무 추워요! 패딩이나 두꺼운 코트가 필요해 보여요!";
+
+    /**
+     * 체감온도를 기반으로 의류 추천 메시지를 반환합니다.
+     *
+     * @param tempFeelsLike 체감온도
+     * @return 스타일 추천 메시지
+     */
+    public String getStyleRecommendation(Double tempFeelsLike) {
+        if (tempFeelsLike >= 28) return VERY_HOT;
+        else if (tempFeelsLike >= 23) return HOT;
+        else if (tempFeelsLike >= 20) return WARM;
+        else if (tempFeelsLike >= 17) return COOL;
+        else if (tempFeelsLike >= 12) return MILD;
+        else if (tempFeelsLike >= 9) return CHILLY;
+        else if (tempFeelsLike >= 5) return COLD;
+        else return FREEZING;
+    }
+
+}


### PR DESCRIPTION
추천 코디 기능을 구현했습니다.

1. jwtToken, 체감온도, 강수량을 전달받음
2. 토큰으로 userId 찾음
3. userId로 등록된 무드리포트 전부 조회
4. 해당 무드리포트들에 있는 weatherId들로 구성된 리스트 생성
5. weatherId 리스트 내의 ID값을 가지는 날씨 정보중에 비슷한 날씨가 있는지 필터링하여 필터링된 weatherId리스트를 생성
6. userId와 필터링된 weatherId를 동시에 가지는 무드리포트를 DB에서 찾고, 해당 무드리포트들로 구성된 리스트 생성
7. 최종적으로, 전달된 무드리포트들의 개수 및 체감온도에 따라서 매핑된 message와 무드리포트들의 정보를 가지는 StylingSuggestionDTO를 같이 반환 

- 추천 코디가 있을시 (유사 날씨에 등록된 코디가 5개 이상): 만족도 기준으로 TOP5 코디 데이터 반환
