### PR TITLE
[Feat] 로그인 수정 및 무드리포트 추가

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 
+    /* Coil */
+    implementation("io.coil-kt:coil-compose:2.4.0")
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -30,6 +30,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kakao602675c3ae2a45daa4343b5a9240f78a" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/frontend/app/src/main/java/com/apptive/wotd/composable/OutfitCard.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/composable/OutfitCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -30,9 +31,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apptive.wotd.R
 import com.apptive.wotd.ui.theme.pretendard
+import coil.compose.rememberAsyncImagePainter
 
 @Composable
-fun OutfitGrid() {
+fun OutfitGrid(imgTop: String? = null, imgBottom: String? = null, imgEtc: String? = null) {
+    val items = listOf(
+        Triple("상의", imgTop, R.drawable.ic_frog_satisfied_4),
+        Triple("하의", imgBottom, R.drawable.ic_frog_satisfied_4),
+        Triple("기타", imgEtc, R.drawable.ic_frog_satisfied_4)
+    )
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
         modifier = Modifier
@@ -43,8 +50,8 @@ fun OutfitGrid() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        items(outfitItems) { item ->
-            OutfitCard(item)
+        items(items) { (category, imageUrl, fallbackRes) ->
+            OutfitCard(category, imageUrl, fallbackRes)
         }
     }
 }
@@ -58,7 +65,7 @@ val outfitItems = listOf(
 )
 
 @Composable
-fun OutfitCard(item: OutfitItem) {
+fun OutfitCard(category: String, imageUrl: String?, fallbackRes: Int) {
     Box(
         modifier = Modifier
             .aspectRatio(1f)
@@ -77,7 +84,7 @@ fun OutfitCard(item: OutfitItem) {
                 .padding(horizontal = 8.dp, vertical = 4.dp)
         ) {
             Text(
-                text = item.category,
+                text = category,
                 style = TextStyle(
                     fontSize = 12.sp,
                     fontFamily = pretendard,
@@ -87,9 +94,14 @@ fun OutfitCard(item: OutfitItem) {
             )
         }
 
+        val painter: Painter = if (!imageUrl.isNullOrBlank()) {
+            rememberAsyncImagePainter(model = imageUrl)
+        } else {
+            painterResource(id = fallbackRes)
+        }
         Image(
-            painter = painterResource(id = item.imageRes),
-            contentDescription = item.category,
+            painter = painter,
+            contentDescription = category,
             contentScale = ContentScale.Fit,
             modifier = Modifier
                 .align(Alignment.Center)

--- a/frontend/app/src/main/java/com/apptive/wotd/model/auth/AuthAPI.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/auth/AuthAPI.kt
@@ -1,5 +1,9 @@
 package com.apptive.wotd.model.auth
 
+import com.apptive.wotd.model.weather.WeatherApi
+import com.apptive.wotd.model.moodreport.MoodReportApi
+import com.apptive.wotd.view.login.ApiResponse
+import com.apptive.wotd.view.login.UserMeResponse
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -10,13 +14,18 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 interface ServerAuthAPI {
-    @POST("auth/kakao/login")
+    @POST("kakao/signup")
     suspend fun signUp(@Body request: SignUpRequest): Response<SignUpResponse>
+
+    @GET("users/me")
+    suspend fun getMe(@Header("Authorization") token: String): Response<ApiResponse<UserMeResponse>>
 }
 
 @Module
@@ -61,5 +70,11 @@ object NetworkModule {
     @Singleton
     fun provideWeatherApi(retrofit: Retrofit): WeatherApi {
         return retrofit.create(WeatherApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideMoodReportApi(retrofit: Retrofit): MoodReportApi {
+        return retrofit.create(MoodReportApi::class.java)
     }
 }

--- a/frontend/app/src/main/java/com/apptive/wotd/model/auth/AuthRepository.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/auth/AuthRepository.kt
@@ -1,6 +1,8 @@
 package com.apptive.wotd.model.auth
 
 import android.util.Log
+import com.apptive.wotd.view.login.ApiResponse
+import com.apptive.wotd.view.login.UserMeResponse
 import javax.inject.Inject
 
 class AuthRepository @Inject constructor(
@@ -24,5 +26,10 @@ class AuthRepository @Inject constructor(
             Log.e("SignUp", "Network error", e)
             Pair(false, null)
         }
+    }
+
+    suspend fun getMe(token: String): ApiResponse<UserMeResponse> {
+        val response = authApi.getMe("Bearer $token")
+        return response.body() ?: throw Exception("No response body")
     }
 }

--- a/frontend/app/src/main/java/com/apptive/wotd/model/auth/KakaoAuth.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/auth/KakaoAuth.kt
@@ -22,18 +22,17 @@ class KaKaoLoginViewModel @Inject constructor(
     val user: State<User?> = _user
     private var currentToken: String? = null
 
-    fun kakaoLogin(context: Context) {
+    fun kakaoLogin(context: Context, onKakaoLoginSuccess: (String) -> Unit) {
         kakaoAuthManager.login(context) { token, error ->
             if (error != null) {
                 Log.e("LoginVM", "로그인 실패", error)
             } else {
                 if (token != null) {
                     currentToken = token.accessToken
-
+                    onKakaoLoginSuccess(token.accessToken)
                 }
                 kakaoAuthManager.getUserInfo { userInfo ->
                     _user.value = userInfo
-                    //Log.d("LoginVM", "사용자 정보: $userInfo")
                 }
             }
         }

--- a/frontend/app/src/main/java/com/apptive/wotd/model/auth/LoginViewModel.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/auth/LoginViewModel.kt
@@ -1,0 +1,47 @@
+package com.apptive.wotd.model.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.apptive.wotd.view.login.UserMeResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+    val loginState = mutableStateOf<LoginResult?>(null)
+    val userMeState = mutableStateOf<UserMeResponse?>(null)
+    val errorState = mutableStateOf<String?>(null)
+
+    fun loginWithJwt(token: String) {
+        viewModelScope.launch {
+            try {
+                val result = authRepository.getMe(token)
+                if (result.isSuccess) {
+                    userMeState.value = result.data
+                    loginState.value = LoginResult.Success
+                } else {
+                    errorState.value = result.message
+                    loginState.value = LoginResult.Failure
+                }
+            } catch (e: Exception) {
+                errorState.value = e.message
+                loginState.value = LoginResult.Failure
+            }
+        }
+    }
+
+    fun clearError() {
+        errorState.value = null
+    }
+}
+
+sealed class LoginResult {
+    object Success : LoginResult()
+    object Failure : LoginResult()
+} 

--- a/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/ImageApi.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/ImageApi.kt
@@ -1,0 +1,16 @@
+package com.apptive.wotd.model.moodreport
+
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface ImageApi {
+    @Multipart
+    @POST("images/upload")
+    suspend fun uploadImage(
+        @Part image: MultipartBody.Part
+    ): Response<ResponseBody>
+} 

--- a/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportApi.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportApi.kt
@@ -1,0 +1,95 @@
+package com.apptive.wotd.model.moodreport
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.GET
+
+data class MoodReportRequestDTO(
+    val date: String = "",
+    val created_at: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    val img_top: String = "",
+    val img_bottom: String = "",
+    val img_etc: String = "",
+    val content: String = "",
+    val score_feel: Double = 0.0,
+    val score_icon: Int? = null
+)
+
+data class MoodReportResponse(
+    val isSuccess: Boolean,
+    val message: String,
+    val data: Any? = null
+)
+
+data class MoodReportListResponse(
+    val isSuccess: Boolean,
+    val message: String,
+    val data: List<MoodReportItem>?
+)
+
+data class MoodReportItem(
+    val weatherData: WeatherData?,
+    val moodReport: MoodReport?
+)
+
+data class WeatherData(
+    val date: String?,
+    val tempFeelsLike: Double?,
+    val tempMin: Double?,
+    val tempMax: Double?,
+    val tempAvg: Double?,
+    val rainAmount: Double?,
+    val description: String?,
+    val latitude: Double?,
+    val longitude: Double?
+)
+
+data class MoodReport(
+    val id: Long?,
+    val userId: Long?,
+    val weatherId: Long?,
+    val date: String?,
+    val created_at: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val img_top: String?,
+    val img_bottom: String?,
+    val img_etc: String?,
+    val content: String?,
+    val score_feel: Double?
+)
+
+data class MoodReportUpdateRequest(
+    val id: Long,
+    val content: String,
+    val score_feel: Double
+)
+
+interface MoodReportApi {
+    @POST("moodReport/add")
+    suspend fun addMoodReport(
+        @Header("Authorization") token: String,
+        @Body request: MoodReportRequestDTO
+    ): Response<MoodReportResponse>
+
+    @GET("moodReport/requestAll")
+    suspend fun getAllMoodReports(
+        @Header("Authorization") token: String
+    ): Response<MoodReportListResponse>
+
+    @GET("moodReport/request/{moodReportId}")
+    suspend fun getMoodReport(
+        @Header("Authorization") token: String,
+        @retrofit2.http.Path("moodReportId") moodReportId: Long
+    ): Response<MoodReportResponse>
+
+    @POST("moodReport/update")
+    suspend fun updateMoodReport(
+        @Header("Authorization") token: String,
+        @Body request: MoodReportUpdateRequest
+    ): Response<MoodReportResponse>
+} 

--- a/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportRepository.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportRepository.kt
@@ -1,0 +1,68 @@
+package com.apptive.wotd.model.moodreport
+
+import android.util.Log
+import javax.inject.Inject
+
+class MoodReportRepository @Inject constructor(
+    private val moodReportApi: MoodReportApi
+) {
+    suspend fun addMoodReport(token: String, request: MoodReportRequestDTO): MoodReportResponse? {
+        return try {
+            val response = moodReportApi.addMoodReport("$token", request)
+            if (response.isSuccessful) {
+                response.body()
+            } else {
+                Log.e("MoodReportRepo", "무드리포트 추가 실패: ${response.errorBody()?.string()}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("MoodReportRepo", "무드리포트 추가 예외", e)
+            null
+        }
+    }
+
+    suspend fun getAllMoodReports(token: String): MoodReportListResponse? {
+        return try {
+            val response = moodReportApi.getAllMoodReports("$token")
+            if (response.isSuccessful) {
+                response.body()
+            } else {
+                Log.e("MoodReportRepo", "전체 무드리포트 조회 실패: ${response.errorBody()?.string()}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("MoodReportRepo", "전체 무드리포트 조회 예외", e)
+            null
+        }
+    }
+
+    suspend fun getMoodReport(token: String, moodReportId: Long): MoodReportResponse? {
+        return try {
+            val response = moodReportApi.getMoodReport("$token", moodReportId)
+            if (response.isSuccessful) {
+                response.body()
+            } else {
+                Log.e("MoodReportRepo", "무드리포트 단건 조회 실패: "+response.errorBody()?.string())
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("MoodReportRepo", "무드리포트 단건 조회 예외", e)
+            null
+        }
+    }
+
+    suspend fun updateMoodReport(token: String, request: MoodReportUpdateRequest): MoodReportResponse? {
+        return try {
+            val response = moodReportApi.updateMoodReport("$token", request)
+            if (response.isSuccessful) {
+                response.body()
+            } else {
+                Log.e("MoodReportRepo", "무드리포트 수정 실패: ${response.errorBody()?.string()}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("MoodReportRepo", "무드리포트 수정 예외", e)
+            null
+        }
+    }
+} 

--- a/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportViewModel.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/moodreport/MoodReportViewModel.kt
@@ -1,0 +1,63 @@
+package com.apptive.wotd.model.moodreport
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MoodReportViewModel @Inject constructor(
+    private val moodReportRepository: MoodReportRepository
+) : ViewModel() {
+    val addState = mutableStateOf<MoodReportResponse?>(null)
+    val errorState = mutableStateOf<String?>(null)
+    val allReportsState = mutableStateOf<List<MoodReportItem>?>(null)
+    val singleReportState = mutableStateOf<MoodReportResponse?>(null)
+
+    fun addMoodReport(token: String, request: MoodReportRequestDTO) {
+        viewModelScope.launch {
+            val result = moodReportRepository.addMoodReport(token, request)
+            if (result != null && result.isSuccess) {
+                addState.value = result
+            } else {
+                errorState.value = result?.message ?: "네트워크 오류"
+            }
+        }
+    }
+
+    fun getAllMoodReports(token: String) {
+        viewModelScope.launch {
+            val result = moodReportRepository.getAllMoodReports(token)
+            if (result != null && result.isSuccess) {
+                allReportsState.value = result.data
+            } else {
+                errorState.value = result?.message ?: "네트워크 오류"
+            }
+        }
+    }
+
+    fun getMoodReport(token: String, moodReportId: Long) {
+        viewModelScope.launch {
+            val result = moodReportRepository.getMoodReport(token, moodReportId)
+            singleReportState.value = result
+        }
+    }
+
+    fun updateMoodReport(token: String, request: MoodReportUpdateRequest) {
+        viewModelScope.launch {
+            val result = moodReportRepository.updateMoodReport(token, request)
+            if (result != null && result.isSuccess) {
+                addState.value = result
+            } else {
+                errorState.value = result?.message ?: "네트워크 오류"
+            }
+        }
+    }
+
+    fun clearState() {
+        addState.value = null
+        errorState.value = null
+    }
+} 

--- a/frontend/app/src/main/java/com/apptive/wotd/model/weather/WeatherAPI.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/weather/WeatherAPI.kt
@@ -1,4 +1,4 @@
-package com.apptive.wotd.model.auth
+package com.apptive.wotd.model.weather
 
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/frontend/app/src/main/java/com/apptive/wotd/model/weather/WeatherViewModel.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/model/weather/WeatherViewModel.kt
@@ -1,4 +1,4 @@
-package com.apptive.wotd.model.auth
+package com.apptive.wotd.model.weather
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
@@ -21,6 +21,8 @@ class WeatherViewModel @Inject constructor(
     val weather: StateFlow<WeatherData?> = _weather
 
     fun fetchWeather(lat: Double, lon: Double, date: LocalDate) {
+        _weather.value = null
+        
         viewModelScope.launch {
             try {
                 Log.d(TAG, "날씨 API 호출 시작 - lat: $lat, lon: $lon, date: $date")
@@ -47,5 +49,9 @@ class WeatherViewModel @Inject constructor(
                 e.printStackTrace()
             }
         }
+    }
+
+    fun clearWeather() {
+        _weather.value = null
     }
 }

--- a/frontend/app/src/main/java/com/apptive/wotd/view/calender/Calender.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/calender/Calender.kt
@@ -1,5 +1,8 @@
 package com.apptive.wotd.view.calender
 
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -49,17 +52,42 @@ import com.apptive.wotd.ui.theme.pretendard
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.YearMonth
+import androidx.compose.ui.platform.LocalContext
+import com.apptive.wotd.model.moodreport.MoodReportViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CalendarPage(
     navController: NavController
 ) {
-    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    val context = LocalContext.current
+    val prefs = context.getSharedPreferences("image_links", Context.MODE_PRIVATE)
+    var selectedDate by remember { mutableStateOf<LocalDate?>(LocalDate.now()) }
     val scrollState = rememberScrollState()
+    val moodReportViewModel: MoodReportViewModel = hiltViewModel()
+    val allReports = moodReportViewModel.allReportsState.value
+    val token = com.apptive.wotd.model.auth.TokenManager.getAccessToken(context)?.trim()
+
+    LaunchedEffect(token) {
+        if (!token.isNullOrBlank()) {
+            moodReportViewModel.getAllMoodReports(token)
+        }
+    }
+    LaunchedEffect(allReports) {
+        if (allReports != null) {
+            Log.d("CalendarPage", "전체 무드리포트 조회 결과: $allReports")
+        }
+    }
 //    LaunchedEffect(Unit) {
 //        navController.navigate("ProgressPage/1")
 //    }
+    val selectedDateString = selectedDate?.toString()
+    val reportForSelectedDate = allReports?.find {
+        it.moodReport?.date == selectedDateString
+    }
+    val hasReportForSelectedDate = reportForSelectedDate != null
+    val isScoreFeelZero = reportForSelectedDate?.moodReport?.score_feel == 0.0
+    val singleReport = moodReportViewModel.singleReportState.value
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -71,7 +99,9 @@ fun CalendarPage(
         CalendarView(
             selectedDate = selectedDate,
             onDateSelected = {
+                Log.d("CalendarPage", "날짜 선택됨: $it")
                 selectedDate = it
+                prefs.edit().putString("selected_date", it.toString()).apply()
             }
         )
         HeightSpacer(28.dp)
@@ -94,15 +124,39 @@ fun CalendarPage(
             )
         }
         HeightSpacer(10.dp)
-        WeatherCard(viewModel = hiltViewModel())
+        WeatherCard(selectedDate = selectedDate, viewModel = hiltViewModel())
         HeightSpacer(8.dp)
-        CameraBtn( {} )
-        HeightSpacer(8.dp)
-        MoodReportBtn(navController)
-        HeightSpacer(16.dp)
-        TodayMoodCard()
-        HeightSpacer(8.dp)
-        OutfitGrid()
-
+        if (!hasReportForSelectedDate) {
+            CameraBtn { navController.navigate("ProgressPage/1") }
+            HeightSpacer(8.dp)
+        } else if (isScoreFeelZero) {
+            // 단건 무드리포트 조회 API 호출
+            LaunchedEffect(reportForSelectedDate?.moodReport?.id) {
+                val id = reportForSelectedDate?.moodReport?.id
+                if (!token.isNullOrBlank() && id != null) {
+                    moodReportViewModel.getMoodReport(token, id)
+                }
+            }
+            LaunchedEffect(singleReport) {
+                if (singleReport != null) {
+                    Log.d("단건 무드리포트 조회", singleReport.toString())
+                }
+            }
+            val moodReportData = singleReport?.data as? Map<*, *>
+            val imgTop = moodReportData?.get("img_top") as? String
+            val imgBottom = moodReportData?.get("img_bottom") as? String
+            val imgEtc = moodReportData?.get("img_etc") as? String
+            CameraBtn { navController.navigate("ProgressPage/1") }
+            HeightSpacer(8.dp)
+            MoodReportBtn(navController)
+            HeightSpacer(8.dp)
+            OutfitGrid(imgTop = imgTop, imgBottom = imgBottom, imgEtc = imgEtc)
+        } else {
+            MoodReportBtn(navController)
+            HeightSpacer(16.dp)
+            TodayMoodCard()
+            HeightSpacer(8.dp)
+            OutfitGrid()
+        }
     }
 }

--- a/frontend/app/src/main/java/com/apptive/wotd/view/calender/WeatherCard.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/calender/WeatherCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -23,9 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -38,14 +35,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.apptive.wotd.R
 import com.apptive.wotd.ui.theme.pretendard
 import java.time.LocalDate
-import com.apptive.wotd.model.auth.WeatherViewModel
-import androidx.hilt.navigation.compose.hiltViewModel
+import com.apptive.wotd.model.weather.WeatherViewModel
 import com.apptive.wotd.composable.HeightSpacer
 import com.apptive.wotd.composable.WidthSpacer
 import com.apptive.wotd.ui.theme.primaryColor
 
 @Composable
 fun WeatherCard(
+    selectedDate: LocalDate? = null,
     viewModel: WeatherViewModel = hiltViewModel()
 ) {
     val keywords = listOf("thunderstorm", "drizzle", "rain", "snow", "clear", "clouds")
@@ -59,11 +56,13 @@ fun WeatherCard(
         ?.let { desc -> keywords.find { keyword -> keyword in desc } }
         ?: "clear"
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(key1 = selectedDate) {
+        val dateToFetch = selectedDate ?: LocalDate.now()
+        Log.d("WeatherCard", "날짜 변경됨: $dateToFetch")
         viewModel.fetchWeather(
             lat = 35.228700446027,
             lon = 129.07900236976,
-            date = LocalDate.of(2025, 5, 12)
+            date = dateToFetch
         )
     }
 

--- a/frontend/app/src/main/java/com/apptive/wotd/view/home/Home.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/home/Home.kt
@@ -39,6 +39,7 @@ import com.apptive.wotd.composable.CameraBtn
 import com.apptive.wotd.composable.HeightSpacer
 import com.apptive.wotd.ui.theme.pretendard
 import com.apptive.wotd.view.calender.WeatherCard
+import java.time.LocalDate
 
 @Composable
 fun HomePage() {
@@ -113,7 +114,7 @@ fun HomePage() {
             }
         }
         HeightSpacer(8.dp)
-        WeatherCard(viewModel = hiltViewModel())
+        WeatherCard(selectedDate = LocalDate.now(), viewModel = hiltViewModel())
         HeightSpacer(12.dp)
         CameraBtn( {} )
         HeightSpacer(12.dp)

--- a/frontend/app/src/main/java/com/apptive/wotd/view/login/Login.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/login/Login.kt
@@ -3,12 +3,17 @@ package com.apptive.wotd.view.login
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -21,7 +26,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -34,20 +43,65 @@ import com.apptive.wotd.model.auth.SignUpViewModel
 import com.apptive.wotd.ui.theme.backgroundColor
 import com.apptive.wotd.ui.theme.pretendard
 import com.apptive.wotd.view.term.TermBottomSheet
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import com.apptive.wotd.model.auth.TokenManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import com.apptive.wotd.model.auth.LoginViewModel
+import com.apptive.wotd.model.auth.LoginResult
+
+data class UserMeResponse(
+    val id: Long,
+    val providerId: String,
+    val providerType: String,
+    val name: String,
+    val latitude: Double?,
+    val longitude: Double?,
+    val allow_notification: Boolean,
+    val createdAt: String
+)
+
+data class ApiResponse<T>(
+    val isSuccess: Boolean,
+    val message: String,
+    val data: T,
+    val errorCode: String?
+)
+
+interface UserApi {
+    @GET("users/me")
+    suspend fun getMe(@Header("Authorization") token: String): retrofit2.Response<ApiResponse<UserMeResponse>>
+}
 
 @Composable
 fun LoginPage(
     navController: NavController,
     signUpViewModel: SignUpViewModel,
     kakaoViewModel: KaKaoLoginViewModel = hiltViewModel(),
+    loginViewModel: LoginViewModel = hiltViewModel(),
 ){
     val user by kakaoViewModel.user
     val context = LocalContext.current
     val token = kakaoViewModel.getAccessToken()
     var termsOfService by remember { mutableStateOf(false) }
+    var isLoginMode by remember { mutableStateOf(false) }
+    val loginState = loginViewModel.loginState.value
+
+    LaunchedEffect(loginState) {
+        if (loginState is LoginResult.Success) {
+            navController.navigate("MainPage") {
+                popUpTo(0)
+            }
+        }
+    }
 
     LaunchedEffect(user) {
-        if (user != null && token != null) {
+        if (user != null && token != null && !isLoginMode) {
             signUpViewModel.updateToken(token)
             Log.d("accessToken: ", signUpViewModel.getToken())
             termsOfService = true
@@ -87,10 +141,27 @@ fun LoginPage(
             textColor = Color.Black,
             textSize = 14,
             textWeight = 600,
-            buttonText = "카카오 회원가입",
+            buttonText = if (isLoginMode) "카카오 로그인" else "카카오 회원가입",
             logoResourceId = R.drawable.ic_kakao_login,
             onClick = {
-                kakaoViewModel.kakaoLogin(context)
+                if (isLoginMode) {
+                    val token = TokenManager.getAccessToken(context) ?: ""
+                    loginViewModel.loginWithJwt(token)
+                } else {
+                    kakaoViewModel.kakaoLogin(context) { kakaoAccessToken ->
+                        signUpViewModel.updateToken(kakaoAccessToken)
+                        signUpViewModel.completeSignUp(
+                            onSuccess = { jwt, name ->
+                                TokenManager.saveData(context, jwt, name)
+                                Log.d("JWT 저장", "token: $jwt")
+                                // navController.navigate("main") 등으로 이동 처리 필요
+                            },
+                            onFailure = {
+                                Log.e("SignUp", "회원가입/로그인 실패")
+                            }
+                        )
+                    }
+                }
             }
         )
         HeightSpacer(8.dp)
@@ -99,11 +170,30 @@ fun LoginPage(
             textColor = Color.Black,
             textSize = 14,
             textWeight = 600,
-            buttonText = "Google 회원가입",
+            buttonText = if (isLoginMode) "Google 로그인" else "Google 회원가입",
             logoResourceId = R.drawable.ic_google_login,
             onClick = {}
         )
-        HeightSpacer(63.dp)
+        TextButton(
+            onClick = {
+                if (!isLoginMode) {
+                    isLoginMode = true
+                }
+            },
+            enabled = !isLoginMode
+        ) {
+            Text(
+                text = "이미 계정이 있으신가요?",
+                style = TextStyle(
+                    fontSize = 12.sp,
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight(400),
+                    color = if (isLoginMode) Color.White else Color(0xFF121417),
+                    textDecoration = TextDecoration.Underline
+                )
+            )
+        }
+        HeightSpacer(20.dp)
     }
 
     if (termsOfService) {

--- a/frontend/app/src/main/java/com/apptive/wotd/view/main/MainPage.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/main/MainPage.kt
@@ -3,7 +3,10 @@ package com.apptive.wotd.view.main
 import android.app.Activity
 import android.content.Intent
 import android.provider.MediaStore
-import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import android.net.Uri
+import android.util.Log
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -15,7 +18,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -56,14 +58,36 @@ import com.apptive.wotd.composable.WhiteScreenModifier
 import com.apptive.wotd.ui.theme.backgroundColor
 import com.apptive.wotd.ui.theme.primaryColor
 import com.apptive.wotd.view.calender.CalendarPage
+import com.apptive.wotd.view.home.HomePage
 import kotlinx.coroutines.delay
+import androidx.compose.runtime.remember
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import com.apptive.wotd.model.moodreport.ImageApi
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import android.content.Context
+import kotlinx.coroutines.withContext
+import com.apptive.wotd.model.moodreport.MoodReportApi
+import com.apptive.wotd.model.moodreport.MoodReportRequestDTO
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import com.apptive.wotd.model.auth.TokenManager
+import com.apptive.wotd.model.moodreport.MoodReportViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun MainPage(
     navController: NavController
 ) {
     var selectedTab by rememberSaveable { mutableStateOf(BottomTab.Calendar) }
-
     Scaffold(
         bottomBar = {
             BottomBar(
@@ -80,7 +104,7 @@ fun MainPage(
                 .background(backgroundColor)
         ) {
             when (selectedTab) {
-                BottomTab.Home -> {}
+                BottomTab.Home -> HomePage()
                 BottomTab.Calendar -> CalendarPage(navController)
                 BottomTab.MyPage -> {}
             }
@@ -94,6 +118,161 @@ fun ProgressPage(
     phase: Int
 ) {
     val context = LocalContext.current
+    val activity = context as? Activity
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+    val moodReportViewModel: MoodReportViewModel = hiltViewModel()
+    val addState by moodReportViewModel.addState
+    val errorState by moodReportViewModel.errorState
+    
+    val prefs = context.getSharedPreferences("image_links", Context.MODE_PRIVATE)
+    var imgTopLink by remember { mutableStateOf(prefs.getString("img_top", "") ?: "") }
+    var imgBottomLink by remember { mutableStateOf(prefs.getString("img_bottom", "") ?: "") }
+    var imgEtcLink by remember { mutableStateOf(prefs.getString("img_etc", "") ?: "") }
+    
+    val selectedDateString = prefs.getString("selected_date", LocalDate.now().toString()) ?: LocalDate.now().toString()
+
+    fun uriToMultipart(context: Context, uri: Uri): MultipartBody.Part? {
+        val inputStream = context.contentResolver.openInputStream(uri) ?: return null
+        val file = File(context.cacheDir, "upload_image.png")
+        val outputStream = FileOutputStream(file)
+        inputStream.copyTo(outputStream)
+        inputStream.close()
+        outputStream.close()
+        val requestFile = file.asRequestBody("image/png".toMediaTypeOrNull())
+        return MultipartBody.Part.createFormData("image", file.name, requestFile)
+    }
+
+    val retrofit = Retrofit.Builder()
+        .baseUrl("http://43.203.233.18:8080/")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+    val imageApi = retrofit.create(ImageApi::class.java)
+    val moodReportApi = retrofit.create(MoodReportApi::class.java)
+
+    val imageLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val data = result.data
+            val uri = data?.data
+            val goNext: () -> Unit = {
+                navController.navigate(
+                    when (phase) {
+                        1 -> "ProgressPage/2"
+                        2 -> "ProgressPage/3"
+                        else -> {
+                            val now = LocalDateTime.now()
+                            val request = MoodReportRequestDTO(
+                                date = selectedDateString,
+                                created_at = LocalDate.now().toString(),
+                                latitude = 35.2433,
+                                longitude = 129.0752,
+                                img_top = imgTopLink,
+                                img_bottom = imgBottomLink,
+                                img_etc = imgEtcLink,
+                                content = " ",
+                                score_feel = 0.0,
+                                score_icon = null
+                            )
+                            val rawToken = TokenManager.getAccessToken(context)
+                            val token = rawToken?.trim()
+                            if (!token.isNullOrBlank()) {
+                                moodReportViewModel.addMoodReport(token, request)
+                            } else {
+                                Log.e("MoodReport", "토큰이 없습니다. 무드리포트 요청을 보내지 않습니다.")
+                            }
+                            "CalendarPage"
+                        }
+                    }
+                )
+            }
+            if (uri != null) {
+                imageUri = uri
+                CoroutineScope(Dispatchers.IO).launch {
+                    val part = uriToMultipart(context, uri)
+                    if (part != null) {
+                        try {
+                            val response = imageApi.uploadImage(part)
+                            if (response.isSuccessful) {
+                                val respString = response.body()?.string()
+                                Log.d("ImageUpload", "업로드 성공: $respString")
+                                // 이미지 링크 저장
+                                when (phase) {
+                                    1 -> {
+                                        imgTopLink = respString ?: ""
+                                        prefs.edit().putString("img_top", imgTopLink).apply()
+                                    }
+                                    2 -> {
+                                        imgBottomLink = respString ?: ""
+                                        prefs.edit().putString("img_bottom", imgBottomLink).apply()
+                                    }
+                                    3 -> {
+                                        imgEtcLink = respString ?: ""
+                                        prefs.edit().putString("img_etc", imgEtcLink).apply()
+                                    }
+                                }
+                                withContext(Dispatchers.Main) { goNext() }
+                            } else {
+                                Log.e("ImageUpload", "업로드 실패: ${response.errorBody()?.string()}")
+                            }
+                        } catch (e: Exception) {
+                            Log.e("ImageUpload", "업로드 예외", e)
+                        }
+                    }
+                }
+            } else if (data?.extras?.get("data") != null) {
+                val bitmap = data.extras?.get("data") as? android.graphics.Bitmap
+                if (bitmap != null) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        val file = File(context.cacheDir, "upload_image_camera.png")
+                        val outputStream = FileOutputStream(file)
+                        bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, outputStream)
+                        outputStream.close()
+                        val requestFile = file.asRequestBody("image/png".toMediaTypeOrNull())
+                        val part = MultipartBody.Part.createFormData("image", file.name, requestFile)
+                        try {
+                            val response = imageApi.uploadImage(part)
+                            if (response.isSuccessful) {
+                                val respString = response.body()?.string()
+                                Log.d("ImageUpload", "업로드 성공: $respString")
+                                // 이미지 링크 저장
+                                when (phase) {
+                                    1 -> {
+                                        imgTopLink = respString ?: ""
+                                        prefs.edit().putString("img_top", imgTopLink).apply()
+                                    }
+                                    2 -> {
+                                        imgBottomLink = respString ?: ""
+                                        prefs.edit().putString("img_bottom", imgBottomLink).apply()
+                                    }
+                                    3 -> {
+                                        imgEtcLink = respString ?: ""
+                                        prefs.edit().putString("img_etc", imgEtcLink).apply()
+                                    }
+                                }
+                                withContext(Dispatchers.Main) { goNext() }
+                            } else {
+                                Log.e("ImageUpload", "업로드 실패: ${response.errorBody()?.string()}")
+                            }
+                        } catch (e: Exception) {
+                            Log.e("ImageUpload", "업로드 예외", e)
+                        }
+                    }
+                } else {
+                    goNext()
+                }
+            }
+        }
+    }
+
+    fun showImagePicker() {
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+        val chooser = Intent.createChooser(galleryIntent, "이미지 선택 또는 촬영")
+        chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(cameraIntent))
+        imageLauncher.launch(chooser)
+    }
+
     Column(
         modifier = WhiteScreenModifier,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -141,27 +320,22 @@ fun ProgressPage(
         )
         Spacer(modifier = Modifier.weight(1f))
         CameraBtn() {
-            /*
-            val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-            if (intent.resolveActivity(context.packageManager) != null) {
-                if (context is Activity) {
-                    context.startActivity(intent)
-                } else {
-                    Toast.makeText(context, "카메라 실행 실패", Toast.LENGTH_SHORT).show()
-                }
-            } else {
-                Toast.makeText(context, "카메라 앱을 찾을 수 없습니다", Toast.LENGTH_SHORT).show()
-            }
-             */
-            navController.navigate(
-                when (phase) {
-                    1 -> "LoadingPage/1"
-                    2 -> "LoadingPage/2"
-                    else -> "LoadingPage/3"
-                }
-            )
+            showImagePicker()
         }
         HeightSpacer(58.dp)
+    }
+
+    // 결과 처리
+    LaunchedEffect(addState) {
+        if (addState != null) {
+            prefs.edit().clear().apply()
+            // 성공 후 페이지 이동 등 처리 가능
+        }
+    }
+    LaunchedEffect(errorState) {
+        if (errorState != null) {
+            // 에러 처리 (예: Toast 등)
+        }
     }
 }
 

--- a/frontend/app/src/main/java/com/apptive/wotd/view/moodreport/MoodReport.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/moodreport/MoodReport.kt
@@ -41,12 +41,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.layout.Box
 
 @Composable
 fun MoodReportPage() {
     var selected by remember { mutableStateOf(0) } // 만족도
     var reviewText by remember { mutableStateOf("") } // 총평
-    val isAllFilled = selected != 0 && reviewText.isNotBlank()
+    val reviewLength = reviewText.length
+    val isAllFilled = selected != 0 && reviewText.isNotBlank() && reviewLength <= 500
     Column (
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -57,7 +59,13 @@ fun MoodReportPage() {
         OutfitGrid()
         SatisfactionEdit(selected = selected, onSelect = { selected = it })
         HeightSpacer(25.dp)
-        OverallReview(reviewText = reviewText, onReviewChange = { reviewText = it })
+        OverallReview(
+            reviewText = reviewText,
+            onReviewChange = {
+                if (it.length <= 500) reviewText = it
+            },
+            reviewLength = reviewLength
+        )
         HeightSpacer(25.dp)
         EditConfirmBtn(
             enabled = isAllFilled,
@@ -135,7 +143,7 @@ fun SatisfactionEdit(selected: Int, onSelect: (Int) -> Unit) {
 }
 
 @Composable
-fun OverallReview(reviewText: String, onReviewChange: (String) -> Unit) {
+fun OverallReview(reviewText: String, onReviewChange: (String) -> Unit, reviewLength: Int) {
     Column (
         modifier = Modifier
             .fillMaxWidth()
@@ -150,34 +158,47 @@ fun OverallReview(reviewText: String, onReviewChange: (String) -> Unit) {
             )
         )
         HeightSpacer(8.dp)
-        BasicTextField(
-            value = reviewText,
-            onValueChange = onReviewChange,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(159.dp)
-                .background(Color(0xFFF5F5F5), RoundedCornerShape(12.dp))
-                .padding(16.dp),
-            textStyle = TextStyle(
-                fontSize = 14.sp,
-                fontFamily = pretendard,
-                color = Color.Black
-            ),
-            decorationBox = { innerTextField ->
-                if (reviewText.isEmpty()) {
-                    Text(
-                        text = "어떤 내용이든 좋아요!",
-                        style = TextStyle(
-                            fontSize = 12.sp,
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight(400),
-                            color = Color(0xFF93979D)
+        Box(modifier = Modifier.fillMaxWidth()) {
+            BasicTextField(
+                value = reviewText,
+                onValueChange = onReviewChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(159.dp)
+                    .background(Color(0xFFF5F5F5), RoundedCornerShape(12.dp))
+                    .padding(16.dp),
+                textStyle = TextStyle(
+                    fontSize = 14.sp,
+                    fontFamily = pretendard,
+                    color = Color.Black
+                ),
+                decorationBox = { innerTextField ->
+                    if (reviewText.isEmpty()) {
+                        Text(
+                            text = "어떤 내용이든 좋아요!",
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                fontFamily = pretendard,
+                                fontWeight = FontWeight(400),
+                                color = Color(0xFF93979D)
+                            )
                         )
-                    )
+                    }
+                    innerTextField()
                 }
-                innerTextField()
-            }
-        )
+            )
+            Text(
+                text = "$reviewLength/500",
+                style = TextStyle(
+                    fontSize = 12.sp,
+                    fontFamily = pretendard,
+                    color = if (reviewLength > 500) Color.Red else Color(0xFF93979D)
+                ),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp)
+            )
+        }
     }
 }
 

--- a/frontend/app/src/main/java/com/apptive/wotd/view/term/TermBottomSheet.kt
+++ b/frontend/app/src/main/java/com/apptive/wotd/view/term/TermBottomSheet.kt
@@ -208,7 +208,7 @@ fun TermBottomSheet(
                         vm.completeSignUp(
                             onSuccess = { token, name ->
                                 TokenManager.saveData(context, token, name)
-                                navController.navigate("CalendarPage") {
+                                navController.navigate("MainPage") {
                                     popUpTo(0)
                                 }
                             },


### PR DESCRIPTION
- 로그인/회원가입 버튼 분리
- 로그인 /users/me 통해서 되게끔 수정
- 달력 누르는 날짜에 따라 날씨 불러오게 수정
- 옷 사진 찍으면 API 통해서 이미지 등록 구현
- 선택한 날짜에 무드리포트 등록되게 구현
- 무드리포트 정보에 따라 캘린더 페이지에 뜨는 ui 다르게 구현