### PR TITLE
Refactor/item

### DIFF
--- a/src/main/java/com/example/apptive_3team/controller/ItemController.java
+++ b/src/main/java/com/example/apptive_3team/controller/ItemController.java
@@ -1,0 +1,107 @@
+package com.example.apptive_3team.controller;
+
+import com.example.apptive_3team.ApiResponse;
+import com.example.apptive_3team.dto.ItemRequestDTO;
+import com.example.apptive_3team.service.ItemService;
+import com.example.apptive_3team.service.KakaoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 챙길 물품 관련 기능을 수행하는 Controller.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/item")
+@RequiredArgsConstructor
+public class ItemController {
+
+    private final ItemService itemService;
+    private final KakaoService kakaoService;
+
+    /**
+     * 챙길 물품 ID를 기반으로 챙길 물품 1개를 조회하는 기능.
+     *
+     * @return 챙길 물품 1개에 대한 정보
+     */
+    @GetMapping("/requestById/{itemId}")
+    public ResponseEntity<?> getItem(@PathVariable Long itemId) {
+        log.info("📥 [GET] item/request/{itemId} API 호출됨");
+
+        ItemRequestDTO data = itemService.getItemById(itemId);
+        return ResponseEntity.ok(ApiResponse.success("챙길 물품 조회를 완료했습니다.", data));
+    }
+
+    /**
+     * 날짜를 기반으로 챙길 물품 1개를 조회하는 기능.
+     *
+     * @return 챙길 물품 1개에 대한 정보
+     */
+    @GetMapping("/requestByDate/{date}")
+    public ResponseEntity<?> getItemsByDate(@RequestHeader("Authorization") String token,
+                                            @PathVariable LocalDate date) {
+        log.info("📥 [GET] item/request/{date} API 호출됨");
+
+        Long user_id = kakaoService.getUserIdFromJwtToken(token);
+
+        Optional<ItemRequestDTO> data = itemService.getItemByDateAndUserId(date, user_id);
+        return ResponseEntity.ok(ApiResponse.success("챙길 물품 조회를 완료했습니다.", data));
+    }
+
+    /**
+     * 챙길 물품의 정보를 DB에 저장하는 기능.
+     *
+     * @param request
+     * @return 저장 여부에 대한 통보
+     */
+    @PostMapping("/add")
+    public ResponseEntity<?> addItem(@RequestHeader("Authorization") String token,
+                                     @Valid @RequestBody ItemRequestDTO request) {
+        log.info("📥 [POST] item/add API 호출됨");
+
+        Long user_id = kakaoService.getUserIdFromJwtToken(token);
+
+        itemService.saveItem(user_id, request);
+        return ResponseEntity.ok(ApiResponse.success("챙길 물품 등록을 완료했습니다."));
+    }
+
+    /**
+     * DB에 저장된 챙길 물품의 정보를 수정하는 기능.
+     *
+     * @param request
+     * @return 수정 여부에 대한 통보
+     */
+    @PostMapping("/update")
+    public ResponseEntity<?> updateItem(@RequestHeader("Authorization") String token,
+                                        @RequestBody ItemRequestDTO request) {
+        log.info("📥 [POST] /item/update API 호출됨");
+
+        Long user_id = kakaoService.getUserIdFromJwtToken(token);
+        itemService.updateItem(user_id, request);
+
+        return ResponseEntity.ok(ApiResponse.success("챙길 물품 수정을 완료했습니다."));
+    }
+
+    /**
+     * DB에 저장된 챙길 물품의 정보를 삭제하는 기능.
+     *
+     * @return 삭제 여부에 대한 통보
+     */
+    @DeleteMapping("/delete/{itemId}")
+    public ResponseEntity<?> deleteItem(@PathVariable Long itemId,
+                                        @RequestHeader("Authorization") String token) {
+        log.info("📥 [DELETE] /item/delete/{itemId} API 호출됨");
+
+        Long user_id = kakaoService.getUserIdFromJwtToken(token);
+        itemService.deleteItem(user_id, itemId); // ← itemId만 넘김
+        return ResponseEntity.ok(ApiResponse.success("챙길 물품 삭제를 완료했습니다."));
+    }
+
+}

--- a/src/main/java/com/example/apptive_3team/dto/ItemRequestDTO.java
+++ b/src/main/java/com/example/apptive_3team/dto/ItemRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.apptive_3team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+/**
+ * 챙길물품의 정보를 전달할 DTO
+ *
+ * @param name 물품 이름 (50자 제한)
+ * @param deadline 물품이 필요한 날짜 (MM-DD)
+ */
+public record ItemRequestDTO(Long id,
+                             @NotBlank String name,
+                             @NotNull LocalDate deadline) {
+}


### PR DESCRIPTION
1. ItemController 내 Item 조회 메서드 2개의 API 경로가 동일하여, API 경로를 수정하였습니다. "/request/{}" > "/requestById/{itemId}", "/requestByDate/{date}"
2. ItemRequestDTO 내 name 필드의 글자수 50자 제한을 제거하였습니다.